### PR TITLE
link to GITHUB taken out and description as HTML possible

### DIFF
--- a/HamEvent/ClientApp/src/app/app.component.html
+++ b/HamEvent/ClientApp/src/app/app.component.html
@@ -15,10 +15,10 @@
     <p class="col-md-4 mb-0 text-body-secondary">© {{'Copyright' | translate}}</p>
 
 
-    <ul class="nav col-md-4 justify-content-end">
+<!--    <ul class="nav col-md-4 justify-content-end">
       <li class="nav-item"> <a class="nav-link" href="https://github.com/bogdanbrudiu/HamSpecialEvent">Contact</a></li>
     </ul>
-  </footer>
+-->  </footer>
 
 
 </div>

--- a/HamEvent/ClientApp/src/app/qsos/qsos.component.html
+++ b/HamEvent/ClientApp/src/app/qsos/qsos.component.html
@@ -1,7 +1,7 @@
 <div class="px-4 text-center border-bottom">
   <h1 class="display-4 fw-bold text-body-emphasis" *ngIf="event">{{event.name}}</h1>
   <div class="col mx-auto">
-    <p *ngIf="event">{{event.description}}</p>
+    <p *ngIf="event" [innerHTML]="event.description"></p>
     <nav class="navbar navbar-expand navbar-light bg-light">
       <div class="container-fluid">
         <div class="collapse navbar-collapse" id="topnavbar">


### PR DESCRIPTION
1/ adding something as 
<br> More details on <a href="https://www.qrz.com/db/yp20kqt" target="_blank">www.qrz.com/db/yp20kqt</a>
in the description, will appear as HTML.
2/ link to Github was taken out